### PR TITLE
fix(linkerd): create dashboard ConfigMap in monitoring namespace

### DIFF
--- a/catalog/kube-prometheus-stack/linkerd/dashboards/deployments.yaml
+++ b/catalog/kube-prometheus-stack/linkerd/dashboards/deployments.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 data:
   linkerd-deployment-dashboard.json: |
@@ -2304,5 +2303,6 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-linkerd-deployment-dashboard
+  namespace: monitoring
   labels:
     grafana_dashboard: "1"

--- a/catalog/kube-prometheus-stack/linkerd/dashboards/routes.yaml
+++ b/catalog/kube-prometheus-stack/linkerd/dashboards/routes.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 data:
   linkerd-route-dashboard.json: |
@@ -1266,5 +1265,6 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-linkerd-route-dashboard
+  namespace: monitoring
   labels:
     grafana_dashboard: "1"

--- a/catalog/kube-prometheus-stack/linkerd/dashboards/services.yaml
+++ b/catalog/kube-prometheus-stack/linkerd/dashboards/services.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 data:
   linkerd-service-dashboard.json: |
@@ -1316,5 +1315,6 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-linkerd-service-dashboard
+  namespace: monitoring
   labels:
     grafana_dashboard: "1"


### PR DESCRIPTION
Fixes

```
Check: CKV_K8S_21: "The default namespace should not be used"
	FAILED for resource: base:ConfigMap.default.grafana-linkerd-deployment-dashboard
	File: /catalog/kube-prometheus-stack/linkerd/dashboards/kustomization.yaml:2-783
	Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/kubernetes-policies/kubernetes-policy-index/bc-k8s-20
```
